### PR TITLE
Remove AbstractString supertype

### DIFF
--- a/src/FilePaths.jl
+++ b/src/FilePaths.jl
@@ -56,11 +56,7 @@ else
     export isexecutable
 end
 
-@compat abstract type AbstractPath <: AbstractString end
-
-# Required methods for subtype of AbstractString
-Base.endof(p::AbstractPath) = endof(String(p))
-Base.next(p::AbstractPath, i::Int) = next(String(p), i)
+@compat abstract type AbstractPath end
 
 # The following should be implemented in the concrete types
 Base.String(path::AbstractPath) = error("`String not implemented")


### PR DESCRIPTION
This probably requires some discussion :) At the end of the day I find [this](https://snarky.ca/why-pathlib-path-doesn-t-inherit-from-str/) convincing.

It also seems the safer choice for now. Given that ``String(p)`` always works, I feel this would just add the right amount of cumbersome to the API.