### PR TITLE
README: add a few more equivalences

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,19 +95,20 @@ homedir() | home()
 cd() | cd()
 joinpath() | joinpath()
 basename() | basename()
-N/A | filename
-N/A | extension
+splitext(basename())[1] | filename
+splitext(basename())[2] | extension
 N/A | extensions
 ispath | exists
 realpath | real
 normpath | norm
 abspath | abs
 relpath | relative
+N/A | glob
 stat | stat
 lstat | lstat
 filemode | mode
-N/A | modified
-N/A | created
+mtime | modified
+ctime | created
 isdir | isdir
 isfile | isfile
 islink | islink
@@ -116,11 +117,11 @@ isfifo | isfifo
 ischardev | ischardev
 isblockdev | isblockdev
 isexecutable (deprecated) | isexecutable
-iswritable (deprecated) | iswritabe
+iswritable (deprecated) | iswritable
 isreadable (deprecated) | isreadable
 ismount | ismount
 isabspath | isabs
-N/A | drive
+splitdrive()[1] | drive
 N/A | root
 expanduser | expanduser
 mkdir | mkdir
@@ -134,8 +135,8 @@ tempname | tmpname
 tempdir | tmpdir 
 mktemp | mktmp 
 mktempdir | mktmpdir 
-chmod (non-recursive) | chmod (recursive unix-only)
-chown (PR) | chown (unix only)
+chmod | chmod (recursive unix-only)
+chown (unix only) | chown (unix only)
 N/A | read
 N/A | write
 

--- a/README.md
+++ b/README.md
@@ -103,7 +103,6 @@ realpath | real
 normpath | norm
 abspath | abs
 relpath | relative
-N/A | glob
 stat | stat
 lstat | lstat
 filemode | mode


### PR DESCRIPTION
Are these mappings correct?

Glancing through, I couldn't quite figure out what `root` was meant to return to add it to the list. (Window's paths are weird in that `C:` is the drive, then the next char indicates whether it's an absolute (`\ ` or `/`) or relative path, then the rest is the path. This means a path could be `C:` meaning "the cwd of drive C", or `C:abc` (the folder "abc" in the cwd on drive C), in addition to `\abc` (the folder "abc" in the root of the current drive), and `C:\abc` (the folder "abc" in the root of drive C), or the path could be a UNC, which starts with `\\`)