### PR TITLE
Correct module lookup in compat macro

### DIFF
--- a/src/compat.jl
+++ b/src/compat.jl
@@ -39,7 +39,7 @@ julia> myjoin("/Users/rory/repos", "FilePaths.jl")
 ```
 """
 macro compat(ex)
-    mod = QuoteNode(__module__)
+    mod::Module = QuoteNode(__module__).value
     new_ex = compat_exp(mod, deepcopy(ex))
 
     return quote

--- a/src/compat.jl
+++ b/src/compat.jl
@@ -39,7 +39,7 @@ julia> myjoin("/Users/rory/repos", "FilePaths.jl")
 ```
 """
 macro compat(ex)
-    mod = @__MODULE__
+    mod = QuoteNode(__module__)
     new_ex = compat_exp(mod, deepcopy(ex))
 
     return quote


### PR DESCRIPTION
`@__MODULE__` in the body a macro expands to that macro's module.
What one actually wants is the `QuoteNode(__module__)`
which expand to the calling code's module.



```
module Bar
    macro get_module_wrong()
        mod = @__MODULE__
        :(string($(esc(mod))))
    end

    macro get_module_right()
        mod =  QuoteNode(__module__)
        :(string($(mod)))
    end
end

module Foo
    using ..Bar: @get_module_right, @get_module_wrong

    println("wrong: ", @get_module_wrong())
    println("right: ", @get_module_right())

end;
```

output:
```
wrong: Main.Bar
right: Main.Foo
```