### PR TITLE
fix FilePathsBase version constraint

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "FilePaths"
 uuid = "8fc22ac5-c921-52a6-82fd-178b2807b824"
 authors = ["Rory Finnegan"]
-version = "0.8.0"
+version = "0.8.1"
 
 [deps]
 FilePathsBase = "48062228-2e41-5def-b9a4-89aafe57970f"

--- a/Project.toml
+++ b/Project.toml
@@ -10,7 +10,7 @@ Reexport = "189a3867-3050-52da-a836-e630ba90ab69"
 URIParser = "30578b45-9adc-5946-b283-645ec420af67"
 
 [compat]
-FilePathsBase = "0.6"
+FilePathsBase = ">= 0.6"
 
 [extras]
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"


### PR DESCRIPTION
The `Project.toml` of FilePaths is out of sync with the latest version of FilePathsBase. This PR loosens the version constraint. Note that it should probably be switched to `"^1.0.0"` once 1.0 is released.