### PR TITLE
Deprecate URIParser; use URIs

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -16,12 +16,14 @@ MacroTools = "0.5"
 Reexport = "0.2, 1.0"
 Requires = "1"
 URIParser = "0.4"
+URIs = "1.1"
 julia = "1"
 
 [extras]
 Glob = "c27321d9-0574-5035-807b-f59d2c89b15c"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 URIParser = "30578b45-9adc-5946-b283-645ec420af67"
+URIs = "5c2747f8-b7ea-4ff2-ba2e-563bfd36b1d4"
 
 [targets]
-test = ["Glob", "Test", "URIParser"]
+test = ["Glob", "Test", "URIs"]

--- a/Project.toml
+++ b/Project.toml
@@ -26,4 +26,4 @@ URIParser = "30578b45-9adc-5946-b283-645ec420af67"
 URIs = "5c2747f8-b7ea-4ff2-ba2e-563bfd36b1d4"
 
 [targets]
-test = ["Glob", "Test", "URIs"]
+test = ["Glob", "Test", "URIParser", "URIs"]

--- a/README.md
+++ b/README.md
@@ -31,8 +31,10 @@ julia> glob("*test*.jl", p"test")
 
 URIParsing:
 ```julia
+julia> using URIs
+
 julia> URI(cwd() / p"test/runtests.jl")
-URI(file:///Users/rory/repos/FilePaths.jl/test/runtests.jl)
+URI("file:///Users/rory/repos/FilePaths.jl/test/runtests.jl")
 ```
 
 Writing `String` and `AbstractPath` compatible code:

--- a/src/FilePaths.jl
+++ b/src/FilePaths.jl
@@ -10,7 +10,8 @@ include("compat.jl")
 
 function __init__()
     @require Glob="c27321d9-0574-5035-807b-f59d2c89b15c" include("glob.jl")
-    @require URIParser="30578b45-9adc-5946-b283-645ec420af67" include("uri.jl")
+    @require URIParser="30578b45-9adc-5946-b283-645ec420af67" include("uriparser.jl")
+    @require URIs="5c2747f8-b7ea-4ff2-ba2e-563bfd36b1d4" include("uris.jl")
 end
 
 end # end of module

--- a/src/uriparser.jl
+++ b/src/uriparser.jl
@@ -1,0 +1,24 @@
+using .URIParser
+
+Base.depwarn("`URIParser` is deprecated, use `URIs` instead.", :URIParser, force=true)
+
+function URIParser.URI(p::AbstractPath; query="", fragment="")
+    if isempty(p.root)
+        throw(ArgumentError("$p is not an absolute path"))
+    end
+
+    b = IOBuffer()
+    print(b, "file://")
+
+    if !isempty(p.drive)
+        print(b, "/")
+        print(b, p.drive)
+    end
+
+    for s in p.segments
+        print(b, "/")
+        print(b, URIParser.escape(s))
+    end
+
+    return URIParser.URI(URIParser.URI(String(take!(b))); query=query, fragment=fragment)
+end

--- a/src/uriparser.jl
+++ b/src/uriparser.jl
@@ -1,8 +1,7 @@
 using .URIParser
 
-Base.depwarn("`URIParser` is deprecated, use `URIs` instead.", :URIParser, force=true)
-
 function URIParser.URI(p::AbstractPath; query="", fragment="")
+    Base.depwarn("`URIParser` is deprecated, use `URIs` instead.", :URIParser)
     if isempty(p.root)
         throw(ArgumentError("$p is not an absolute path"))
     end

--- a/src/uris.jl
+++ b/src/uris.jl
@@ -1,6 +1,8 @@
-using .URIParser
+using .URIs
 
-function URIParser.URI(p::AbstractPath; query="", fragment="")
+const absent = SubString("absent", 1, 0)
+
+function URIs.URI(p::AbstractPath; query=absent, fragment=absent)
     if isempty(p.root)
         throw(ArgumentError("$p is not an absolute path"))
     end
@@ -15,8 +17,8 @@ function URIParser.URI(p::AbstractPath; query="", fragment="")
 
     for s in p.segments
         print(b, "/")
-        print(b, URIParser.escape(s))
+        print(b, URIs.escapeuri(s))
     end
 
-    return URIParser.URI(URIParser.URI(String(take!(b))); query=query, fragment=fragment)
+    return URIs.URI(URIs.URI(String(take!(b))); query=query, fragment=fragment)
 end

--- a/test/test_uri.jl
+++ b/test/test_uri.jl
@@ -1,10 +1,19 @@
+using URIParser
 using URIs
 using FilePaths
 
-@testset "URI" begin
-    @test string(URI(p"/foo/bar")) == "file:///foo/bar"
-    @test string(URI(p"/foo foo/bar")) == "file:///foo%20foo/bar"
-    @test_throws ArgumentError URI(p"foo/bar")
-    @test string(URI(WindowsPath("C:\\foo\\bar"))) == "file:///C:/foo/bar"
-    @test string(URI(p"/foo/bar", query="querypart", fragment="fragmentpart")) == "file:///foo/bar?querypart#fragmentpart"
+@testset "URIParser" begin
+    @test string(URIParser.URI(p"/foo/bar")) == "file:///foo/bar"
+    @test string(URIParser.URI(p"/foo foo/bar")) == "file:///foo%20foo/bar"
+    @test_throws ArgumentError URIParser.URI(p"foo/bar")
+    @test string(URIParser.URI(WindowsPath("C:\\foo\\bar"))) == "file:///C:/foo/bar"
+    @test string(URIParser.URI(p"/foo/bar", query="querypart", fragment="fragmentpart")) == "file:///foo/bar?querypart#fragmentpart"
+end
+
+@testset "URIs" begin
+    @test string(URIs.URI(p"/foo/bar")) == "file:///foo/bar"
+    @test string(URIs.URI(p"/foo foo/bar")) == "file:///foo%20foo/bar"
+    @test_throws ArgumentError URIs.URI(p"foo/bar")
+    @test string(URIs.URI(WindowsPath("C:\\foo\\bar"))) == "file:///C:/foo/bar"
+    @test string(URIs.URI(p"/foo/bar", query="querypart", fragment="fragmentpart")) == "file:///foo/bar?querypart#fragmentpart"
 end

--- a/test/test_uri.jl
+++ b/test/test_uri.jl
@@ -1,4 +1,4 @@
-using URIParser
+using URIs
 using FilePaths
 
 @testset "URI" begin


### PR DESCRIPTION
I'm not sure if this is the best way to do the `depwarn`.  Let me know if you have suggestions for changes.  Fixes #56