### PR TITLE
add FileIO support

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -4,14 +4,18 @@ authors = ["Rory Finnegan"]
 version = "0.8.3"
 
 [deps]
+FileIO = "5789e2e9-d7fb-5bc7-8068-2c6fae9b9549"
 FilePathsBase = "48062228-2e41-5def-b9a4-89aafe57970f"
 MacroTools = "1914dd2f-81c6-5fcd-8719-6d5c9610ff09"
 Reexport = "189a3867-3050-52da-a836-e630ba90ab69"
 Requires = "ae029012-a4dd-5104-9daa-d747884805df"
 
 [compat]
+FileIO = "1.6"
 FilePathsBase = "0.9"
 Glob = "1"
+ImageIO = "0.4, 0.5"
+ImageCore = "0.9, 0.10"
 MacroTools = "0.5"
 Reexport = "0.2, 1.0"
 Requires = "1"
@@ -20,10 +24,13 @@ URIs = "1.1"
 julia = "1"
 
 [extras]
+FileIO = "5789e2e9-d7fb-5bc7-8068-2c6fae9b9549"
 Glob = "c27321d9-0574-5035-807b-f59d2c89b15c"
+ImageCore = "a09fc81d-aa75-5fe9-8630-4744c3626534"
+ImageIO = "82e4d734-157c-48bb-816b-45c225c6df19"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 URIParser = "30578b45-9adc-5946-b283-645ec420af67"
 URIs = "5c2747f8-b7ea-4ff2-ba2e-563bfd36b1d4"
 
 [targets]
-test = ["Glob", "Test", "URIParser", "URIs"]
+test = ["FileIO", "Glob", "ImageCore", "ImageIO", "Test", "URIParser", "URIs"]

--- a/src/FilePaths.jl
+++ b/src/FilePaths.jl
@@ -12,6 +12,7 @@ function __init__()
     @require Glob="c27321d9-0574-5035-807b-f59d2c89b15c" include("glob.jl")
     @require URIParser="30578b45-9adc-5946-b283-645ec420af67" include("uriparser.jl")
     @require URIs="5c2747f8-b7ea-4ff2-ba2e-563bfd36b1d4" include("uris.jl")
+    @require FileIO="5789e2e9-d7fb-5bc7-8068-2c6fae9b9549" include("fileio.jl")
 end
 
 end # end of module

--- a/src/fileio.jl
+++ b/src/fileio.jl
@@ -1,0 +1,4 @@
+using .FileIO
+
+# Most IO backends only support string format
+FileIO.File{F}(filepath::SystemPath) where F<:DataFormat = File{F}(convert(String, filepath))

--- a/test/fileio.jl
+++ b/test/fileio.jl
@@ -1,0 +1,28 @@
+module TestFileIO
+
+using Test
+using FileIO
+using ImageCore
+using FilePathsBase
+using FilePathsBase: /
+using FilePaths
+
+@testset "File/Stream" begin
+    imgdata = repeat(distinguishable_colors(16), inner=(1, 16)) # (16, 16) RGB image
+
+    mktempdir(SystemPath) do testdir
+        savepath = testdir / "data.png"
+        @test_nowarn save(savepath, imgdata)
+        @test load(savepath) == imgdata
+
+        savepath = testdir / "data_io.png"
+        @test_nowarn open(savepath, "w") do io
+            save(Stream{format"PNG"}(io, savepath), imgdata)
+        end
+        @test imgdata == open(savepath, "r") do io
+            load(Stream{format"PNG"}(io, savepath))
+        end
+    end
+end
+
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -6,5 +6,6 @@ using Test
 include("compat.jl")
 include("glob.jl")
 include("test_uri.jl")
+include("fileio.jl")
 
 end


### PR DESCRIPTION
Partially address https://github.com/JuliaIO/FileIO.jl/issues/315 by normalizing the SystemPath to string. This is probably not a good fix as I never used FilePath before...
However, requiring all IO backends to provide FilePath support is perhaps not practical at all.

cc: @jkrumbiegel