### PR TITLE
Remove deprication for URIParser

### DIFF
--- a/src/uriparser.jl
+++ b/src/uriparser.jl
@@ -1,7 +1,6 @@
 using .URIParser
 
 function URIParser.URI(p::AbstractPath; query="", fragment="")
-    Base.depwarn("`URIParser` is deprecated, use `URIs` instead.", :URIParser)
     if isempty(p.root)
         throw(ArgumentError("$p is not an absolute path"))
     end


### PR DESCRIPTION
I don't think it is good practice to throw deprecation warnings in this packge about _other_ packages. If URIParser.jl wants to throw that deprecation, then it should do that. Plus, there are packages that pull in URIParser for whatever reason, and then this package here starting to throw deprecation warnings is not really helpful.