### PR TITLE
Requires.jl -> pkg extensions, dropping pre-1.9 Julia versions

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -33,21 +33,12 @@ jobs:
             version: 1
             arch: x86
     steps:
-      - uses: actions/checkout@v2
-      - uses: julia-actions/setup-julia@v1
+      - uses: actions/checkout@v4
+      - uses: julia-actions/setup-julia@latest
         with:
           version: ${{ matrix.version }}
           arch: ${{ matrix.arch }}
-      - uses: actions/cache@v1
-        env:
-          cache-name: cache-artifacts
-        with:
-          path: ~/.julia/artifacts
-          key: ${{ runner.os }}-test-${{ env.cache-name }}-${{ hashFiles('**/Project.toml') }}
-          restore-keys: |
-            ${{ runner.os }}-test-${{ env.cache-name }}-
-            ${{ runner.os }}-test-
-            ${{ runner.os }}-
+      - uses: julia-actions/cache@v2
       - uses: julia-actions/julia-buildpkg@latest
       - run: |
           git config --global user.name Tester

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -2,7 +2,7 @@ name: CI
 # Run on master, tags, or any pull request
 on:
   schedule:
-    - cron: '0 1 * * *'  # Daily at 1 AM UTC (7 PM CST)
+    - cron: "0 1 * * *" # Daily at 1 AM UTC (7 PM CST)
   push:
     branches: [master]
     tags: ["*"]
@@ -24,9 +24,9 @@ jobs:
         arch:
           - x64
         include:
-          # Add a 1.0 job just to make sure we still support it
+          # Add a 1.9 job just to make sure we still support it
           - os: ubuntu-latest
-            version: 1.0.5
+            version: 1.9
             arch: x64
           # Add a 32-bit job to ensure we don't have any 64-bit specific logic
           - os: ubuntu-latest

--- a/Project.toml
+++ b/Project.toml
@@ -1,23 +1,31 @@
 name = "FilePaths"
 uuid = "8fc22ac5-c921-52a6-82fd-178b2807b824"
 authors = ["Rory Finnegan"]
-version = "0.8.3"
+version = "0.9.0"
 
 [deps]
 FilePathsBase = "48062228-2e41-5def-b9a4-89aafe57970f"
 MacroTools = "1914dd2f-81c6-5fcd-8719-6d5c9610ff09"
 Reexport = "189a3867-3050-52da-a836-e630ba90ab69"
-Requires = "ae029012-a4dd-5104-9daa-d747884805df"
+
+[weakdeps]
+Glob = "c27321d9-0574-5035-807b-f59d2c89b15c"
+URIParser = "30578b45-9adc-5946-b283-645ec420af67"
+URIs = "5c2747f8-b7ea-4ff2-ba2e-563bfd36b1d4"
+
+[extensions]
+FilePathsGlobExt = "Glob"
+FilePathsURIParserExt = "URIParser"
+FilePathsURIsExt = "URIs"
 
 [compat]
 FilePathsBase = "0.9"
 Glob = "1"
 MacroTools = "0.5"
 Reexport = "0.2, 1.0"
-Requires = "1"
 URIParser = "0.4"
 URIs = "1.1"
-julia = "1"
+julia = "1.9"
 
 [extras]
 Glob = "c27321d9-0574-5035-807b-f59d2c89b15c"

--- a/ext/FilePathsGlobExt.jl
+++ b/ext/FilePathsGlobExt.jl
@@ -1,8 +1,13 @@
-using .Glob
-using .Glob: GlobMatch
+module FilePathsGlobExt
+
+using Glob
+using Glob: GlobMatch
+using FilePaths
 
 Base.readdir(pattern::GlobMatch, prefix::AbstractPath) = glob(pattern, prefix)
 
 function Glob.glob(pattern, prefix::T) where T<:AbstractPath
     return [parse(T, m) for m in glob(pattern, string(prefix))]
+end
+
 end

--- a/ext/FilePathsURIParserExt.jl
+++ b/ext/FilePathsURIParserExt.jl
@@ -4,7 +4,6 @@ using URIParser
 using FilePaths
 
 function URIParser.URI(p::AbstractPath; query="", fragment="")
-    Base.depwarn("`URIParser` is deprecated, use `URIs` instead.", :URIParser)
     if isempty(p.root)
         throw(ArgumentError("$p is not an absolute path"))
     end

--- a/ext/FilePathsURIParserExt.jl
+++ b/ext/FilePathsURIParserExt.jl
@@ -1,4 +1,7 @@
-using .URIParser
+module FilePathsURIParserExt
+
+using URIParser
+using FilePaths
 
 function URIParser.URI(p::AbstractPath; query="", fragment="")
     Base.depwarn("`URIParser` is deprecated, use `URIs` instead.", :URIParser)
@@ -20,4 +23,6 @@ function URIParser.URI(p::AbstractPath; query="", fragment="")
     end
 
     return URIParser.URI(URIParser.URI(String(take!(b))); query=query, fragment=fragment)
+end
+
 end

--- a/ext/FilePathsURIsExt.jl
+++ b/ext/FilePathsURIsExt.jl
@@ -1,4 +1,7 @@
-using .URIs
+module FilePathsURIsExt
+
+using URIs
+using FilePaths
 
 const absent = SubString("absent", 1, 0)
 
@@ -21,4 +24,6 @@ function URIs.URI(p::AbstractPath; query=absent, fragment=absent)
     end
 
     return URIs.URI(URIs.URI(String(take!(b))); query=query, fragment=fragment)
+end
+
 end

--- a/src/FilePaths.jl
+++ b/src/FilePaths.jl
@@ -2,16 +2,9 @@ module FilePaths
 
 using MacroTools
 using Reexport
-using Requires
 
 @reexport using FilePathsBase
 
 include("compat.jl")
-
-function __init__()
-    @require Glob="c27321d9-0574-5035-807b-f59d2c89b15c" include("glob.jl")
-    @require URIParser="30578b45-9adc-5946-b283-645ec420af67" include("uriparser.jl")
-    @require URIs="5c2747f8-b7ea-4ff2-ba2e-563bfd36b1d4" include("uris.jl")
-end
 
 end # end of module


### PR DESCRIPTION
Closes #62 

This might also be a more immediate resolution to https://github.com/rofinn/FilePathsBase.jl/pull/186 and https://github.com/davidanthoff/Electron.jl/pull/140 while we disentangle the weird test dependency between FilePathsBase and JLSO/BSON.